### PR TITLE
feat(group-members): get group-members without reloading page

### DIFF
--- a/client/public/auth.scss
+++ b/client/public/auth.scss
@@ -18,6 +18,7 @@ body {
 
   .modal-overlay {
     display: none;
+    background: none
   }
 
   #brand {
@@ -272,6 +273,7 @@ textarea#message {
 
 #sidenav-overlay {
   z-index: 0;
+  background: none;
 }
 
 .username {
@@ -305,7 +307,7 @@ th {
 }
 
 button#side-nav.button-collapse {
-  color: teal;
+  color: teal
 }
 
 

--- a/client/src/containers/AddUserForm.jsx
+++ b/client/src/containers/AddUserForm.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import initialState from '../initialState';
-import { searchUsers, addUserRequest } from '../actions';
+import { searchUsers, addUserRequest, groupMembers } from '../actions';
 /**
  * @class AddUserForm
  * @extends React.Component
@@ -67,6 +67,7 @@ export class AddUserForm extends Component {
     event.preventDefault();
     this.props.addUserRequest(this.state, this.props.groupId)
       .then(() => {
+        this.props.groupMembers(this.props.groupId);
         this.setState({
           username: initialState.addUser
         });
@@ -117,12 +118,12 @@ AddUserForm.propTypes = {
   addUserRequest: PropTypes.func.isRequired,
   groupId: PropTypes.string.isRequired,
   searchUsers: PropTypes.func.isRequired,
-  result: PropTypes.array.isRequired
-
+  result: PropTypes.array.isRequired,
+  groupMembers: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
   result: state.search
 });
 
-export default connect(mapStateToProps, { searchUsers, addUserRequest })(AddUserForm);
+export default connect(mapStateToProps, { searchUsers, addUserRequest, groupMembers })(AddUserForm);

--- a/client/src/containers/Message.jsx
+++ b/client/src/containers/Message.jsx
@@ -38,7 +38,6 @@ export class Message extends Component {
   componentDidMount() {
     this.props.getUserGroups();
     this.props.getGroupMessages(this.props.match.params.groupId);
-    this.props.groupMembers(this.props.match.params.groupId);
     this.props.getAllUsers();
 
     $('select').material_select();


### PR DESCRIPTION
## What does this PR do?

- get group-members without reloading the page

## Description
- remove overlay background from side-nav and modal

- get group members from Adduser component onSubmit action

## Relevant Pivotal Tracker stories

- https://www.pivotaltracker.com/story/show/152994316

finishes: feat/show-groupmembers-without-reload/152994316